### PR TITLE
Fix query exception arguments

### DIFF
--- a/src/GoogleClient.php
+++ b/src/GoogleClient.php
@@ -107,7 +107,7 @@ class GoogleClient
                 if ($errorDom->isCaptcha()) {
                     throw new GoogleCaptchaException(new GoogleCaptcha($errorDom));
                 } else {
-                    throw new RequestErrorException($errorDom);
+                    throw new RequestErrorException();
                 }
             }
         }

--- a/src/GoogleClient.php
+++ b/src/GoogleClient.php
@@ -19,7 +19,7 @@ use Serps\SearchEngine\Google\Page\GoogleSerp;
 use Serps\SearchEngine\Google\GoogleUrl;
 use Zend\Diactoros\Request;
 use Serps\Exception\RequestError\PageNotFoundException;
-use Serps\Exception\RequestError\RequestErrorException;
+use Serps\Exception\RequestError\ResponseException;
 
 /**
  * Google client the handles google url routing, dom object constructions and request errors
@@ -74,7 +74,7 @@ class GoogleClient
      * @return GoogleSerp
      * @throws Exception
      * @throws PageNotFoundException
-     * @throws RequestErrorException
+     * @throws ResponseException
      * @throws GoogleCaptchaException
      */
     public function query(GoogleUrlInterface $googleUrl, Proxy $proxy = null, CookieJarInterface $cookieJar = null)
@@ -107,7 +107,7 @@ class GoogleClient
                 if ($errorDom->isCaptcha()) {
                     throw new GoogleCaptchaException(new GoogleCaptcha($errorDom));
                 } else {
-                    throw new RequestErrorException($response->getPageContent());
+                    throw new ResponseException($response);
                 }
             }
         }

--- a/src/GoogleClient.php
+++ b/src/GoogleClient.php
@@ -107,7 +107,7 @@ class GoogleClient
                 if ($errorDom->isCaptcha()) {
                     throw new GoogleCaptchaException(new GoogleCaptcha($errorDom));
                 } else {
-                    throw new RequestErrorException();
+                    throw new RequestErrorException($response->getPageContent());
                 }
             }
         }

--- a/src/Parser/AbstractParser.php
+++ b/src/Parser/AbstractParser.php
@@ -49,7 +49,7 @@ abstract class AbstractParser
 
     protected function createResultSet(GoogleDom $googleDom)
     {
-        $startingAt = $googleDom->getUrl()->getResultsPerPage() * $googleDom->getUrl()->getParamValue('start', 0);
+        $startingAt = (int) $googleDom->getUrl()->getParamValue('start', 0);
         return new IndexedResultSet($startingAt);
     }
 


### PR DESCRIPTION
The RequestErrorException extends from the \Exception class and first argument can't be the GoogleError, in there must be a string or empty. 

My fix throw new RequestErrorException without arguments.