### PR TITLE
Fix notice when parsing news description

### DIFF
--- a/src/Parser/Evaluated/Rule/Natural/InTheNews.php
+++ b/src/Parser/Evaluated/Rule/Natural/InTheNews.php
@@ -56,7 +56,7 @@ class InTheNews implements \Serps\SearchEngine\Google\Parser\ParsingRuleInterace
             $card['url'] = $aTag->getAttribute('href');
             $card['description'] = function () use ($googleDOM, $node) {
                 $span = $googleDOM->getXpath()->query("descendant::span[@class='_dwd st s std']", $node);
-                if ($span) {
+                if ($span && $span->length > 0) {
                     return  $span->item(0)->nodeValue;
                 }
                 return null;


### PR DESCRIPTION
In cases, when multiple news are displayed, smaller news blocks does not have description block.
In that case $span is actually not null, but calling $span->getItem(0) returns null and we get 'trying to get property from a non object'.