### PR TITLE
Filter elements group

### DIFF
--- a/src/Parser/AbstractParser.php
+++ b/src/Parser/AbstractParser.php
@@ -65,6 +65,9 @@ abstract class AbstractParser
 
         foreach ($elementGroups as $group) {
             foreach ($rules as $rule) {
+                if (!($group instanceof \DOMElement)) {
+                    continue;
+                }
                 $match = $rule->match($googleDom, $group);
                 if ($match instanceof \DOMNodeList) {
                     $this->parseGroups($group->childNodes, $resultSet, $googleDom);

--- a/src/Parser/AbstractParser.php
+++ b/src/Parser/AbstractParser.php
@@ -64,10 +64,10 @@ abstract class AbstractParser
         $rules = $this->getRules();
 
         foreach ($elementGroups as $group) {
+            if (!($group instanceof \DOMElement)) {
+                continue;
+            }
             foreach ($rules as $rule) {
-                if (!($group instanceof \DOMElement)) {
-                    continue;
-                }
                 $match = $rule->match($googleDom, $group);
                 if ($match instanceof \DOMNodeList) {
                     $this->parseGroups($group->childNodes, $resultSet, $googleDom);


### PR DESCRIPTION
In rare cases elements group can contain DOMText instead of DOMElement, which causes fatal crash.

This is more of a quick fix.