### PR TITLE
fix total number of results - GG changes id name

### DIFF
--- a/src/Page/GoogleSerp.php
+++ b/src/Page/GoogleSerp.php
@@ -78,8 +78,14 @@ class GoogleSerp extends GoogleDom
     public function getNumberOfResults()
     {
         $item = $this->cssQuery('#resultStats');
+
         if ($item->length != 1) {
-            return null;
+
+            $item = $this->cssQuery('#result-stats');
+
+            if ($item->length != 1) {
+                return null;
+            }
         }
 
         // number of results is followed by time, we want to targets the first node (text node) that is the number of


### PR DESCRIPTION
If I'm not mistaken, Google has changed id name of total result from #resultStats -> #result-stats, so this patch will fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/serp-spider/search-engine-google/128)
<!-- Reviewable:end -->
